### PR TITLE
Add .idea/ directory to .gitignore and update docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build/
 
 ### Mac OS ###
 .DS_Store
+/.idea/


### PR DESCRIPTION
The .idea directory includes IDE-specific configurations that don't belong in the git repository, hence we've added it to .gitignore to prevent accidental commits. Docker-compose.yaml file has also been updated for better project-specific naming conventions and enhanced compatibility across different environments.